### PR TITLE
Fix LoadWanFunLora

### DIFF
--- a/comfyui/wan2_1_fun/nodes.py
+++ b/comfyui/wan2_1_fun/nodes.py
@@ -234,7 +234,6 @@ class LoadWanFunLora:
                 "funmodels": ("FunModels",),
                 "lora_name": (folder_paths.get_filename_list("loras"), {"default": None,}),
                 "strength_model": ("FLOAT", {"default": 1.0, "min": -100.0, "max": 100.0, "step": 0.01}),
-                "lora_cache":([False, True],  {"default": False,}),
             }
         }
     RETURN_TYPES = ("FunModels",)
@@ -251,6 +250,8 @@ class LoadWanFunLora:
                     'model_name': funmodels["model_name"],
                     'loras': funmodels.get("loras", []) + [folder_paths.get_full_path("loras", lora_name)],
                     'strength_model': funmodels.get("strength_model", []) + [strength_model],
+                    'config': funmodels["config"],
+                    'model_type': funmodels["model_type"],
                 }, 
             )
         else:


### PR DESCRIPTION
## Background

I was doing some testing with the Comfy Nodes using the LoadWanFunLora node with providing my 720p 14b T2V WAN 2.1 lora.

I ran into a few issues when using the node being:
* `load_lora()` got an unexpected keyword 'lora_cache'` - This was due to the node requiring 4 arguments but the function only took 3 (`lora_cache` not being one of them)
* Then KeyErrors for `config` and `model_type` as they weren't being passed through with the node.


The way I was using it:
![image](https://github.com/user-attachments/assets/dcf96017-fc09-42b9-9356-31082a747272)
