### PR TITLE
docs(Comfyui-README): Fix incorrect ModelScope link for Wan2.1-720P

### DIFF
--- a/comfyui/README.md
+++ b/comfyui/README.md
@@ -67,7 +67,7 @@ V1.0:
 | Wan2.1-T2V-1.3B | [🤗Link](https://huggingface.co/alibaba-pai/Wan2.1-Fun-1.3B-InP) | [😄Link](https://www.modelscope.cn/models/Wan-AI/Wan2.1-T2V-1.3B) | Wanxiang 2.1-1.3B text-to-video weights |
 | Wan2.1-T2V-14B | [🤗Link](https://huggingface.co/alibaba-pai/Wan2.1-Fun-1.3B-InP) | [😄Link](https://www.modelscope.cn/models/Wan-AI/Wan2.1-T2V-14B) | Wanxiang 2.1-14B text-to-video weights |
 | Wan2.1-I2V-14B-480P | [🤗Link](https://huggingface.co/alibaba-pai/Wan2.1-Fun-14B-InP) | [😄Link](https://www.modelscope.cn/models/Wan-AI/Wan2.1-I2V-14B-480P) | Wanxiang 2.1-14B-480P image-to-video weights |
-| Wan2.1-I2V-14B-720P| [🤗Link](https://huggingface.co/alibaba-pai/Wan2.1-Fun-14B-InP) | [😄Link](https://www.modelscope.cn/models/Wan-AI/Wan2.1-I2V-14B-480P) | Wanxiang 2.1-14B-720P image-to-video weights |
+| Wan2.1-I2V-14B-720P| [🤗Link](https://huggingface.co/alibaba-pai/Wan2.1-Fun-14B-InP) | [😄Link](https://www.modelscope.cn/models/Wan-AI/Wan2.1-I2V-14B-720P) | Wanxiang 2.1-14B-720P image-to-video weights |
 
 #### iii. CogVideoX-Fun
 


### PR DESCRIPTION
Hi there,

I noticed that in the `Comfyui/README.md` file, under the `#### ii. Wan2.1` section, the ModelScope link for the **Wan2.1-I2V-14B-720P** model was incorrectly pointing to the 480P model's page.

This pull request corrects the URL to point to the correct 720P model page on ModelScope.

- **Before:** `.../Wan2.1-I2V-14B-480P`
- **After:** `.../Wan2.1-I2V-14B-720P`

Thanks for your great work on this project!