### PR TITLE
Fix: ensure pixel_values are truncated before generating mask

### DIFF
--- a/scripts/cogvideox_fun/train.py
+++ b/scripts/cogvideox_fun/train.py
@@ -1136,9 +1136,7 @@ def main():
                         transforms.Resize(resize_size, interpolation=transforms.InterpolationMode.BILINEAR),  # Image.BICUBIC
                         transforms.CenterCrop(closest_size),
                         transforms.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5], inplace=True),
-                    ])
-                new_examples["pixel_values"].append(transform(pixel_values))
-                new_examples["text"].append(example["text"])
+                    ])                
 
                 batch_video_length = int(min(batch_video_length, len(pixel_values)))
 
@@ -1156,6 +1154,9 @@ def main():
                 if batch_video_length <= 0:
                     batch_video_length = 1
 
+                new_examples["pixel_values"].append(transform(pixel_values)[:batch_video_length])
+                new_examples["text"].append(example["text"])
+
                 if args.train_mode != "normal":
                     mask = get_random_mask(new_examples["pixel_values"][-1].size())
                     mask_pixel_values = new_examples["pixel_values"][-1] * (1 - mask) + torch.ones_like(new_examples["pixel_values"][-1]) * -1 * mask
@@ -1163,10 +1164,10 @@ def main():
                     new_examples["mask"].append(mask)
 
             # Limit the number of frames to the same
-            new_examples["pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["pixel_values"]])
+            new_examples["pixel_values"] = torch.stack([example for example in new_examples["pixel_values"]])
             if args.train_mode != "normal":
-                new_examples["mask_pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["mask_pixel_values"]])
-                new_examples["mask"] = torch.stack([example[:batch_video_length] for example in new_examples["mask"]])
+                new_examples["mask_pixel_values"] = torch.stack([example for example in new_examples["mask_pixel_values"]])
+                new_examples["mask"] = torch.stack([example for example in new_examples["mask"]])
 
             # Encode prompts when enable_text_encoder_in_dataloader=True
             if args.enable_text_encoder_in_dataloader:

--- a/scripts/cogvideox_fun/train_lora.py
+++ b/scripts/cogvideox_fun/train_lora.py
@@ -1074,9 +1074,7 @@ def main():
                         transforms.Resize(resize_size, interpolation=transforms.InterpolationMode.BILINEAR),  # Image.BICUBIC
                         transforms.CenterCrop(closest_size),
                         transforms.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5], inplace=True),
-                    ])
-                new_examples["pixel_values"].append(transform(pixel_values))
-                new_examples["text"].append(example["text"])
+                    ])                
 
                 batch_video_length = int(min(batch_video_length, len(pixel_values)))
 
@@ -1093,6 +1091,9 @@ def main():
 
                 if batch_video_length <= 0:
                     batch_video_length = 1
+                
+                new_examples["pixel_values"].append(transform(pixel_values)[:batch_video_length])
+                new_examples["text"].append(example["text"])
 
                 if args.train_mode != "normal":
                     mask = get_random_mask(new_examples["pixel_values"][-1].size())
@@ -1101,10 +1102,10 @@ def main():
                     new_examples["mask"].append(mask)
 
             # Limit the number of frames to the same
-            new_examples["pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["pixel_values"]])
+            new_examples["pixel_values"] = torch.stack([example for example in new_examples["pixel_values"]])
             if args.train_mode != "normal":
-                new_examples["mask_pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["mask_pixel_values"]])
-                new_examples["mask"] = torch.stack([example[:batch_video_length] for example in new_examples["mask"]])
+                new_examples["mask_pixel_values"] = torch.stack([example for example in new_examples["mask_pixel_values"]])
+                new_examples["mask"] = torch.stack([example for example in new_examples["mask"]])
 
             # Encode prompts when enable_text_encoder_in_dataloader=True
             if args.enable_text_encoder_in_dataloader:

--- a/scripts/wan2.1/train.py
+++ b/scripts/wan2.1/train.py
@@ -1302,9 +1302,7 @@ def main():
                         transforms.Resize(resize_size, interpolation=transforms.InterpolationMode.BILINEAR),  # Image.BICUBIC
                         transforms.CenterCrop(closest_size),
                         transforms.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5], inplace=True),
-                    ])
-                new_examples["pixel_values"].append(transform(pixel_values))
-                new_examples["text"].append(example["text"])
+                    ])                
 
                 batch_video_length = int(min(batch_video_length, len(pixel_values)))
 
@@ -1313,6 +1311,9 @@ def main():
 
                 if batch_video_length <= 0:
                     batch_video_length = 1
+                
+                new_examples["pixel_values"].append(transform(pixel_values)[:batch_video_length])
+                new_examples["text"].append(example["text"])
 
                 if args.train_mode != "normal":
                     mask = get_random_mask(new_examples["pixel_values"][-1].size(), image_start_only=True)
@@ -1327,10 +1328,10 @@ def main():
                     new_examples["clip_pixel_values"].append(clip_pixel_values)
 
             # Limit the number of frames to the same
-            new_examples["pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["pixel_values"]])
+            new_examples["pixel_values"] = torch.stack([example for example in new_examples["pixel_values"]])
             if args.train_mode != "normal":
-                new_examples["mask_pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["mask_pixel_values"]])
-                new_examples["mask"] = torch.stack([example[:batch_video_length] for example in new_examples["mask"]])
+                new_examples["mask_pixel_values"] = torch.stack([example for example in new_examples["mask_pixel_values"]])
+                new_examples["mask"] = torch.stack([example for example in new_examples["mask"]])
                 new_examples["clip_pixel_values"] = torch.stack([example for example in new_examples["clip_pixel_values"]])
 
             # Encode prompts when enable_text_encoder_in_dataloader=True

--- a/scripts/wan2.1/train_lora.py
+++ b/scripts/wan2.1/train_lora.py
@@ -1227,9 +1227,7 @@ def main():
                         transforms.Resize(resize_size, interpolation=transforms.InterpolationMode.BILINEAR),  # Image.BICUBIC
                         transforms.CenterCrop(closest_size),
                         transforms.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5], inplace=True),
-                    ])
-                new_examples["pixel_values"].append(transform(pixel_values))
-                new_examples["text"].append(example["text"])
+                    ])                
 
                 batch_video_length = int(min(batch_video_length, len(pixel_values)))
 
@@ -1238,6 +1236,9 @@ def main():
 
                 if batch_video_length <= 0:
                     batch_video_length = 1
+                
+                new_examples["pixel_values"].append(transform(pixel_values)[:batch_video_length])
+                new_examples["text"].append(example["text"])
 
                 if args.train_mode != "normal":
                     mask = get_random_mask(new_examples["pixel_values"][-1].size(), image_start_only=True)
@@ -1252,10 +1253,10 @@ def main():
                     new_examples["clip_pixel_values"].append(clip_pixel_values)
 
             # Limit the number of frames to the same
-            new_examples["pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["pixel_values"]])
+            new_examples["pixel_values"] = torch.stack([example for example in new_examples["pixel_values"]])
             if args.train_mode != "normal":
-                new_examples["mask_pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["mask_pixel_values"]])
-                new_examples["mask"] = torch.stack([example[:batch_video_length] for example in new_examples["mask"]])
+                new_examples["mask_pixel_values"] = torch.stack([example for example in new_examples["mask_pixel_values"]])
+                new_examples["mask"] = torch.stack([example for example in new_examples["mask"]])
                 new_examples["clip_pixel_values"] = torch.stack([example for example in new_examples["clip_pixel_values"]])
 
             # Encode prompts when enable_text_encoder_in_dataloader=True

--- a/scripts/wan2.1_fun/train.py
+++ b/scripts/wan2.1_fun/train.py
@@ -1297,9 +1297,7 @@ def main():
                         transforms.Resize(resize_size, interpolation=transforms.InterpolationMode.BILINEAR),  # Image.BICUBIC
                         transforms.CenterCrop(closest_size),
                         transforms.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5], inplace=True),
-                    ])
-                new_examples["pixel_values"].append(transform(pixel_values))
-                new_examples["text"].append(example["text"])
+                    ])                
 
                 batch_video_length = int(min(batch_video_length, len(pixel_values)))
 
@@ -1308,6 +1306,9 @@ def main():
 
                 if batch_video_length <= 0:
                     batch_video_length = 1
+
+                new_examples["pixel_values"].append(transform(pixel_values)[:batch_video_length])
+                new_examples["text"].append(example["text"])
 
                 if args.train_mode != "normal":
                     mask = get_random_mask(new_examples["pixel_values"][-1].size())
@@ -1322,10 +1323,10 @@ def main():
                     new_examples["clip_pixel_values"].append(clip_pixel_values)
 
             # Limit the number of frames to the same
-            new_examples["pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["pixel_values"]])
+            new_examples["pixel_values"] = torch.stack([example for example in new_examples["pixel_values"]])
             if args.train_mode != "normal":
-                new_examples["mask_pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["mask_pixel_values"]])
-                new_examples["mask"] = torch.stack([example[:batch_video_length] for example in new_examples["mask"]])
+                new_examples["mask_pixel_values"] = torch.stack([example for example in new_examples["mask_pixel_values"]])
+                new_examples["mask"] = torch.stack([example for example in new_examples["mask"]])
                 new_examples["clip_pixel_values"] = torch.stack([example for example in new_examples["clip_pixel_values"]])
 
             # Encode prompts when enable_text_encoder_in_dataloader=True

--- a/scripts/wan2.1_fun/train_lora.py
+++ b/scripts/wan2.1_fun/train_lora.py
@@ -1225,9 +1225,7 @@ def main():
                         transforms.Resize(resize_size, interpolation=transforms.InterpolationMode.BILINEAR),  # Image.BICUBIC
                         transforms.CenterCrop(closest_size),
                         transforms.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5], inplace=True),
-                    ])
-                new_examples["pixel_values"].append(transform(pixel_values))
-                new_examples["text"].append(example["text"])
+                    ])                
 
                 batch_video_length = int(min(batch_video_length, len(pixel_values)))
 
@@ -1236,6 +1234,9 @@ def main():
 
                 if batch_video_length <= 0:
                     batch_video_length = 1
+
+                new_examples["pixel_values"].append(transform(pixel_values)[:batch_video_length])
+                new_examples["text"].append(example["text"])
 
                 if args.train_mode != "normal":
                     mask = get_random_mask(new_examples["pixel_values"][-1].size())
@@ -1250,10 +1251,10 @@ def main():
                     new_examples["clip_pixel_values"].append(clip_pixel_values)
 
             # Limit the number of frames to the same
-            new_examples["pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["pixel_values"]])
+            new_examples["pixel_values"] = torch.stack([example for example in new_examples["pixel_values"]])
             if args.train_mode != "normal":
-                new_examples["mask_pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["mask_pixel_values"]])
-                new_examples["mask"] = torch.stack([example[:batch_video_length] for example in new_examples["mask"]])
+                new_examples["mask_pixel_values"] = torch.stack([example for example in new_examples["mask_pixel_values"]])
+                new_examples["mask"] = torch.stack([example for example in new_examples["mask"]])
                 new_examples["clip_pixel_values"] = torch.stack([example for example in new_examples["clip_pixel_values"]])
 
             # Encode prompts when enable_text_encoder_in_dataloader=True

--- a/scripts/wan2.2/train.py
+++ b/scripts/wan2.2/train.py
@@ -1299,9 +1299,7 @@ def main():
                         transforms.Resize(resize_size, interpolation=transforms.InterpolationMode.BILINEAR),  # Image.BICUBIC
                         transforms.CenterCrop(closest_size),
                         transforms.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5], inplace=True),
-                    ])
-                new_examples["pixel_values"].append(transform(pixel_values))
-                new_examples["text"].append(example["text"])
+                    ])                
 
                 batch_video_length = int(min(batch_video_length, len(pixel_values)))
 
@@ -1310,6 +1308,9 @@ def main():
 
                 if batch_video_length <= 0:
                     batch_video_length = 1
+
+                new_examples["pixel_values"].append(transform(pixel_values)[:batch_video_length])
+                new_examples["text"].append(example["text"])
 
                 if args.train_mode != "normal":
                     mask = get_random_mask(new_examples["pixel_values"][-1].size(), image_start_only=True)
@@ -1324,10 +1325,10 @@ def main():
                     new_examples["clip_pixel_values"].append(clip_pixel_values)
 
             # Limit the number of frames to the same
-            new_examples["pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["pixel_values"]])
+            new_examples["pixel_values"] = torch.stack([example for example in new_examples["pixel_values"]])
             if args.train_mode != "normal":
-                new_examples["mask_pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["mask_pixel_values"]])
-                new_examples["mask"] = torch.stack([example[:batch_video_length] for example in new_examples["mask"]])
+                new_examples["mask_pixel_values"] = torch.stack([example for example in new_examples["mask_pixel_values"]])
+                new_examples["mask"] = torch.stack([example for example in new_examples["mask"]])
                 new_examples["clip_pixel_values"] = torch.stack([example for example in new_examples["clip_pixel_values"]])
 
             # Encode prompts when enable_text_encoder_in_dataloader=True

--- a/scripts/wan2.2/train_lora.py
+++ b/scripts/wan2.2/train_lora.py
@@ -1235,9 +1235,7 @@ def main():
                         transforms.Resize(resize_size, interpolation=transforms.InterpolationMode.BILINEAR),  # Image.BICUBIC
                         transforms.CenterCrop(closest_size),
                         transforms.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5], inplace=True),
-                    ])
-                new_examples["pixel_values"].append(transform(pixel_values))
-                new_examples["text"].append(example["text"])
+                    ])                
 
                 batch_video_length = int(min(batch_video_length, len(pixel_values)))
 
@@ -1246,6 +1244,9 @@ def main():
 
                 if batch_video_length <= 0:
                     batch_video_length = 1
+
+                new_examples["pixel_values"].append(transform(pixel_values)[:batch_video_length])
+                new_examples["text"].append(example["text"])
 
                 if args.train_mode != "normal":
                     mask = get_random_mask(new_examples["pixel_values"][-1].size(), image_start_only=True)
@@ -1260,10 +1261,10 @@ def main():
                     new_examples["clip_pixel_values"].append(clip_pixel_values)
 
             # Limit the number of frames to the same
-            new_examples["pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["pixel_values"]])
+            new_examples["pixel_values"] = torch.stack([example for example in new_examples["pixel_values"]])
             if args.train_mode != "normal":
-                new_examples["mask_pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["mask_pixel_values"]])
-                new_examples["mask"] = torch.stack([example[:batch_video_length] for example in new_examples["mask"]])
+                new_examples["mask_pixel_values"] = torch.stack([example for example in new_examples["mask_pixel_values"]])
+                new_examples["mask"] = torch.stack([example for example in new_examples["mask"]])
                 new_examples["clip_pixel_values"] = torch.stack([example for example in new_examples["clip_pixel_values"]])
 
             # Encode prompts when enable_text_encoder_in_dataloader=True

--- a/scripts/wan2.2_fun/train.py
+++ b/scripts/wan2.2_fun/train.py
@@ -1305,9 +1305,7 @@ def main():
                         transforms.Resize(resize_size, interpolation=transforms.InterpolationMode.BILINEAR),  # Image.BICUBIC
                         transforms.CenterCrop(closest_size),
                         transforms.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5], inplace=True),
-                    ])
-                new_examples["pixel_values"].append(transform(pixel_values))
-                new_examples["text"].append(example["text"])
+                    ])                
 
                 batch_video_length = int(min(batch_video_length, len(pixel_values)))
 
@@ -1316,6 +1314,9 @@ def main():
 
                 if batch_video_length <= 0:
                     batch_video_length = 1
+                
+                new_examples["pixel_values"].append(transform(pixel_values)[:batch_video_length])
+                new_examples["text"].append(example["text"])
 
                 if args.train_mode != "normal":
                     mask = get_random_mask(new_examples["pixel_values"][-1].size())
@@ -1330,10 +1331,10 @@ def main():
                     new_examples["clip_pixel_values"].append(clip_pixel_values)
 
             # Limit the number of frames to the same
-            new_examples["pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["pixel_values"]])
+            new_examples["pixel_values"] = torch.stack([example for example in new_examples["pixel_values"]])
             if args.train_mode != "normal":
-                new_examples["mask_pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["mask_pixel_values"]])
-                new_examples["mask"] = torch.stack([example[:batch_video_length] for example in new_examples["mask"]])
+                new_examples["mask_pixel_values"] = torch.stack([example for example in new_examples["mask_pixel_values"]])
+                new_examples["mask"] = torch.stack([example for example in new_examples["mask"]])
                 new_examples["clip_pixel_values"] = torch.stack([example for example in new_examples["clip_pixel_values"]])
 
             # Encode prompts when enable_text_encoder_in_dataloader=True

--- a/scripts/wan2.2_fun/train_control.py
+++ b/scripts/wan2.2_fun/train_control.py
@@ -1325,8 +1325,18 @@ def main():
                         transforms.CenterCrop(closest_size),
                     ])
     
-                new_examples["pixel_values"].append(transform(pixel_values))
-                new_examples["control_pixel_values"].append(transform(control_pixel_values))
+                # Magvae needs the number of frames to be 4n + 1.
+                batch_video_length = int(
+                    min(
+                        batch_video_length,
+                        (len(pixel_values) - 1) // sample_n_frames_bucket_interval * sample_n_frames_bucket_interval + 1, 
+                    )
+                )
+                if batch_video_length == 0:
+                    batch_video_length = 1
+
+                new_examples["pixel_values"].append(transform(pixel_values)[:batch_video_length])
+                new_examples["control_pixel_values"].append(transform(control_pixel_values)[:batch_video_length])
             
                 if args.train_mode == "control_camera_ref":
                     control_camera_values = example.get("control_camera_values", None)
@@ -1344,15 +1354,6 @@ def main():
                         new_examples["control_camera_values"].append(transform_no_normalize(local_control_camera_values))
                 
                 new_examples["text"].append(example["text"])
-                # Magvae needs the number of frames to be 4n + 1.
-                batch_video_length = int(
-                    min(
-                        batch_video_length,
-                        (len(pixel_values) - 1) // sample_n_frames_bucket_interval * sample_n_frames_bucket_interval + 1, 
-                    )
-                )
-                if batch_video_length == 0:
-                    batch_video_length = 1
 
                 if args.train_mode != "control":
                     if args.control_ref_image == "first_frame":
@@ -1387,17 +1388,17 @@ def main():
                         new_examples["mask"].append(mask)
 
             # Limit the number of frames to the same
-            new_examples["pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["pixel_values"]])
-            new_examples["control_pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["control_pixel_values"]])
+            new_examples["pixel_values"] = torch.stack([example for example in new_examples["pixel_values"]])
+            new_examples["control_pixel_values"] = torch.stack([example for example in new_examples["control_pixel_values"]])
             if args.train_mode != "control":
-                new_examples["ref_pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["ref_pixel_values"]])
+                new_examples["ref_pixel_values"] = torch.stack([example for example in new_examples["ref_pixel_values"]])
                 new_examples["clip_pixel_values"] = torch.stack([example for example in new_examples["clip_pixel_values"]])
                 new_examples["clip_idx"] = torch.tensor(new_examples["clip_idx"])
             if args.train_mode == "control_camera_ref":
-                new_examples["control_camera_values"] = torch.stack([example[:batch_video_length] for example in new_examples["control_camera_values"]])
+                new_examples["control_camera_values"] = torch.stack([example for example in new_examples["control_camera_values"]])
             if args.add_inpaint_info:
-                new_examples["mask_pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["mask_pixel_values"]])
-                new_examples["mask"] = torch.stack([example[:batch_video_length] for example in new_examples["mask"]])
+                new_examples["mask_pixel_values"] = torch.stack([example for example in new_examples["mask_pixel_values"]])
+                new_examples["mask"] = torch.stack([example for example in new_examples["mask"]])
 
             # Encode prompts when enable_text_encoder_in_dataloader=True
             if args.enable_text_encoder_in_dataloader:

--- a/scripts/wan2.2_fun/train_control.py
+++ b/scripts/wan2.2_fun/train_control.py
@@ -1336,7 +1336,7 @@ def main():
                     batch_video_length = 1
 
                 new_examples["pixel_values"].append(transform(pixel_values)[:batch_video_length])
-                new_examples["control_pixel_values"].append(transform(control_pixel_values)[:batch_video_length])
+                new_examples["control_pixel_values"].append(transform(control_pixel_values))
             
                 if args.train_mode == "control_camera_ref":
                     control_camera_values = example.get("control_camera_values", None)
@@ -1389,13 +1389,13 @@ def main():
 
             # Limit the number of frames to the same
             new_examples["pixel_values"] = torch.stack([example for example in new_examples["pixel_values"]])
-            new_examples["control_pixel_values"] = torch.stack([example for example in new_examples["control_pixel_values"]])
+            new_examples["control_pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["control_pixel_values"]])
             if args.train_mode != "control":
                 new_examples["ref_pixel_values"] = torch.stack([example for example in new_examples["ref_pixel_values"]])
                 new_examples["clip_pixel_values"] = torch.stack([example for example in new_examples["clip_pixel_values"]])
                 new_examples["clip_idx"] = torch.tensor(new_examples["clip_idx"])
             if args.train_mode == "control_camera_ref":
-                new_examples["control_camera_values"] = torch.stack([example for example in new_examples["control_camera_values"]])
+                new_examples["control_camera_values"] = torch.stack([example[:batch_video_length] for example in new_examples["control_camera_values"]])
             if args.add_inpaint_info:
                 new_examples["mask_pixel_values"] = torch.stack([example for example in new_examples["mask_pixel_values"]])
                 new_examples["mask"] = torch.stack([example for example in new_examples["mask"]])

--- a/scripts/wan2.2_fun/train_control_lora.py
+++ b/scripts/wan2.2_fun/train_control_lora.py
@@ -1334,19 +1334,6 @@ def main():
                 new_examples["mask_pixel_values"] = torch.stack([example for example in new_examples["mask_pixel_values"]])
                 new_examples["mask"] = torch.stack([example for example in new_examples["mask"]])
 
-            # Limit the number of frames to the same
-            new_examples["pixel_values"] = torch.stack([example for example in new_examples["pixel_values"]])
-            new_examples["control_pixel_values"] = torch.stack([example for example in new_examples["control_pixel_values"]])
-            if args.train_mode != "control":
-                new_examples["ref_pixel_values"] = torch.stack([example for example in new_examples["ref_pixel_values"]])
-                new_examples["clip_pixel_values"] = torch.stack([example for example in new_examples["clip_pixel_values"]])
-                new_examples["clip_idx"] = torch.tensor(new_examples["clip_idx"])
-            if args.train_mode == "control_camera_ref":
-                new_examples["control_camera_values"] = torch.stack([example for example in new_examples["control_camera_values"]])
-            if args.add_inpaint_info:
-                new_examples["mask_pixel_values"] = torch.stack([example for example in new_examples["mask_pixel_values"]])
-                new_examples["mask"] = torch.stack([example for example in new_examples["mask"]])
-
             # Encode prompts when enable_text_encoder_in_dataloader=True
             if args.enable_text_encoder_in_dataloader:
                 prompt_ids = tokenizer(

--- a/scripts/wan2.2_fun/train_control_lora.py
+++ b/scripts/wan2.2_fun/train_control_lora.py
@@ -1259,8 +1259,18 @@ def main():
                         transforms.CenterCrop(closest_size),
                     ])
     
-                new_examples["pixel_values"].append(transform(pixel_values))
-                new_examples["control_pixel_values"].append(transform(control_pixel_values))
+                # Magvae needs the number of frames to be 4n + 1.
+                batch_video_length = int(
+                    min(
+                        batch_video_length,
+                        (len(pixel_values) - 1) // sample_n_frames_bucket_interval * sample_n_frames_bucket_interval + 1, 
+                    )
+                )
+                if batch_video_length == 0:
+                    batch_video_length = 1
+
+                new_examples["pixel_values"].append(transform(pixel_values)[:batch_video_length])
+                new_examples["control_pixel_values"].append(transform(control_pixel_values)[:batch_video_length])
             
                 if args.train_mode == "control_camera_ref":
                     control_camera_values = example.get("control_camera_values", None)
@@ -1278,15 +1288,6 @@ def main():
                         new_examples["control_camera_values"].append(transform_no_normalize(local_control_camera_values))
                 
                 new_examples["text"].append(example["text"])
-                # Magvae needs the number of frames to be 4n + 1.
-                batch_video_length = int(
-                    min(
-                        batch_video_length,
-                        (len(pixel_values) - 1) // sample_n_frames_bucket_interval * sample_n_frames_bucket_interval + 1, 
-                    )
-                )
-                if batch_video_length == 0:
-                    batch_video_length = 1
 
                 if args.train_mode != "control":
                     if args.control_ref_image == "first_frame":
@@ -1321,17 +1322,17 @@ def main():
                         new_examples["mask"].append(mask)
 
             # Limit the number of frames to the same
-            new_examples["pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["pixel_values"]])
-            new_examples["control_pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["control_pixel_values"]])
+            new_examples["pixel_values"] = torch.stack([example for example in new_examples["pixel_values"]])
+            new_examples["control_pixel_values"] = torch.stack([example for example in new_examples["control_pixel_values"]])
             if args.train_mode != "control":
-                new_examples["ref_pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["ref_pixel_values"]])
+                new_examples["ref_pixel_values"] = torch.stack([example for example in new_examples["ref_pixel_values"]])
                 new_examples["clip_pixel_values"] = torch.stack([example for example in new_examples["clip_pixel_values"]])
                 new_examples["clip_idx"] = torch.tensor(new_examples["clip_idx"])
             if args.train_mode == "control_camera_ref":
-                new_examples["control_camera_values"] = torch.stack([example[:batch_video_length] for example in new_examples["control_camera_values"]])
+                new_examples["control_camera_values"] = torch.stack([example for example in new_examples["control_camera_values"]])
             if args.add_inpaint_info:
-                new_examples["mask_pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["mask_pixel_values"]])
-                new_examples["mask"] = torch.stack([example[:batch_video_length] for example in new_examples["mask"]])
+                new_examples["mask_pixel_values"] = torch.stack([example for example in new_examples["mask_pixel_values"]])
+                new_examples["mask"] = torch.stack([example for example in new_examples["mask"]])
 
             # Encode prompts when enable_text_encoder_in_dataloader=True
             if args.enable_text_encoder_in_dataloader:

--- a/scripts/wan2.2_fun/train_control_lora.py
+++ b/scripts/wan2.2_fun/train_control_lora.py
@@ -1270,7 +1270,7 @@ def main():
                     batch_video_length = 1
 
                 new_examples["pixel_values"].append(transform(pixel_values)[:batch_video_length])
-                new_examples["control_pixel_values"].append(transform(control_pixel_values)[:batch_video_length])
+                new_examples["control_pixel_values"].append(transform(control_pixel_values))
             
                 if args.train_mode == "control_camera_ref":
                     control_camera_values = example.get("control_camera_values", None)
@@ -1320,6 +1320,19 @@ def main():
                         # + torch.ones_like(new_examples["pixel_values"][-1]) * -1 * mask
                         new_examples["mask_pixel_values"].append(mask_pixel_values)
                         new_examples["mask"].append(mask)
+
+            # Limit the number of frames to the same
+            new_examples["pixel_values"] = torch.stack([example for example in new_examples["pixel_values"]])
+            new_examples["control_pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["control_pixel_values"]])
+            if args.train_mode != "control":
+                new_examples["ref_pixel_values"] = torch.stack([example for example in new_examples["ref_pixel_values"]])
+                new_examples["clip_pixel_values"] = torch.stack([example for example in new_examples["clip_pixel_values"]])
+                new_examples["clip_idx"] = torch.tensor(new_examples["clip_idx"])
+            if args.train_mode == "control_camera_ref":
+                new_examples["control_camera_values"] = torch.stack([example[:batch_video_length] for example in new_examples["control_camera_values"]])
+            if args.add_inpaint_info:
+                new_examples["mask_pixel_values"] = torch.stack([example for example in new_examples["mask_pixel_values"]])
+                new_examples["mask"] = torch.stack([example for example in new_examples["mask"]])
 
             # Limit the number of frames to the same
             new_examples["pixel_values"] = torch.stack([example for example in new_examples["pixel_values"]])

--- a/scripts/wan2.2_fun/train_lora.py
+++ b/scripts/wan2.2_fun/train_lora.py
@@ -1234,9 +1234,7 @@ def main():
                         transforms.Resize(resize_size, interpolation=transforms.InterpolationMode.BILINEAR),  # Image.BICUBIC
                         transforms.CenterCrop(closest_size),
                         transforms.Normalize(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5], inplace=True),
-                    ])
-                new_examples["pixel_values"].append(transform(pixel_values))
-                new_examples["text"].append(example["text"])
+                    ])                
 
                 batch_video_length = int(min(batch_video_length, len(pixel_values)))
 
@@ -1245,6 +1243,9 @@ def main():
 
                 if batch_video_length <= 0:
                     batch_video_length = 1
+                
+                new_examples["pixel_values"].append(transform(pixel_values)[:batch_video_length])
+                new_examples["text"].append(example["text"])
 
                 if args.train_mode != "normal":
                     mask = get_random_mask(new_examples["pixel_values"][-1].size())
@@ -1259,10 +1260,10 @@ def main():
                     new_examples["clip_pixel_values"].append(clip_pixel_values)
 
             # Limit the number of frames to the same
-            new_examples["pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["pixel_values"]])
+            new_examples["pixel_values"] = torch.stack([example for example in new_examples["pixel_values"]])
             if args.train_mode != "normal":
-                new_examples["mask_pixel_values"] = torch.stack([example[:batch_video_length] for example in new_examples["mask_pixel_values"]])
-                new_examples["mask"] = torch.stack([example[:batch_video_length] for example in new_examples["mask"]])
+                new_examples["mask_pixel_values"] = torch.stack([example for example in new_examples["mask_pixel_values"]])
+                new_examples["mask"] = torch.stack([example for example in new_examples["mask"]])
                 new_examples["clip_pixel_values"] = torch.stack([example for example in new_examples["clip_pixel_values"]])
 
             # Encode prompts when enable_text_encoder_in_dataloader=True


### PR DESCRIPTION
Previously, the mask was generated before applying batch_video_length 
truncation. This could cause the intended mask type (e.g., flf2v) to shift 
semantics after truncation (e.g., turning into i2v), which is not expected.

Now, pixel_values are first truncated, and the mask is generated based on 
the truncated sequence to preserve the intended masking behavior.