### PR TITLE
support qwenimage edit 2511

### DIFF
--- a/videox_fun/models/qwenimage_transformer2d.py
+++ b/videox_fun/models/qwenimage_transformer2d.py
@@ -15,14 +15,14 @@
 
 
 import functools
-import inspect
 import glob
+import inspect
 import json
 import math
-from math import prod
 import os
 import types
 import warnings
+from math import prod
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -53,9 +53,9 @@ from torch import nn
 from ..dist import (QwenImageMultiGPUsAttnProcessor2_0,
                     get_sequence_parallel_rank,
                     get_sequence_parallel_world_size, get_sp_group)
+from ..utils import cfg_skip
 from .attention_utils import attention
 from .cache_utils import TeaCache
-from ..utils import cfg_skip
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
 
@@ -282,6 +282,7 @@ class QwenEmbedRope(nn.Module):
 
         freqs = torch.cat([freqs_frame, freqs_height, freqs_width], dim=-1).reshape(seq_lens, -1)
         return freqs.clone().contiguous()
+
 
 class QwenEmbedLayer3DRope(nn.Module):
     def __init__(self, theta: int, axes_dim: List[int], scale_rope=False):
@@ -922,7 +923,6 @@ class QwenImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fro
         txt_seq_lens: Optional[List[int]] = None,
         guidance: torch.Tensor = None,  # TODO: this should probably be removed
         attention_kwargs: Optional[Dict[str, Any]] = None,
-        controlnet_block_samples=None,
         additional_t_cond=None,
         cond_flag: bool = True,
         return_dict: bool = True,
@@ -1075,6 +1075,8 @@ class QwenImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fro
                             encoder_hidden_states_mask,
                             temb,
                             image_rotary_emb,
+                            attention_kwargs,
+                            modulate_index,
                             **ckpt_kwargs,
                         )
 
@@ -1110,6 +1112,8 @@ class QwenImageTransformer2DModel(ModelMixin, ConfigMixin, PeftAdapterMixin, Fro
                         encoder_hidden_states_mask,
                         temb,
                         image_rotary_emb,
+                        attention_kwargs,
+                        modulate_index,
                         **ckpt_kwargs,
                     )
 


### PR DESCRIPTION
I migrated the implementation of Qwen Image Edit 2511, but I found that the results are slightly different from those of Diffusers. I used FP8 quantization and LightX2V acceleration with LoRA.

test case:
- input_images:
  <img width="261" height="405" alt="image" src="https://github.com/user-attachments/assets/6d9ab022-f835-4452-acb3-56cd0999de55" /><img width="250" height="300" alt="image" src="https://github.com/user-attachments/assets/919a1f48-ad6d-4ad2-b424-c619a95812cf" />
  

- prompt
  Keep the reference character's outfit and hairstyle unchanged. In a cozy café with vintage decor, the character from image_1 sits by the window and stares at her untouched coffee, while the character from image_2 slides into the seat across from her, waving a menu and cheerfully suggesting they share a slice of cake. anime style with semi-impasto brushstrokes, high aesthetic quality.

- result
  <img width="832" height="1280" alt="image" src="https://github.com/user-attachments/assets/659dc70b-7868-46f1-8ae1-a427081b65fd" />

- diffusers result
  <img width="832" height="1280" alt="image" src="https://github.com/user-attachments/assets/94613085-e610-40c3-9369-e0f30bcac183" />
