### PR TITLE
fix: replace 74 bare excepts with except Exception

### DIFF
--- a/comfyui/flux2/nodes.py
+++ b/comfyui/flux2/nodes.py
@@ -598,10 +598,10 @@ class LoadFlux2TextEncoderModel:
             [os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "models/Diffusion_Transformer")] # Possible folder names to check
         try:
             tokenizer_path = search_sub_dir_in_possible_folders(possible_folders, sub_dir_name="flux2_tokenizer")
-        except:
+        except Exception:
             try:
                 tokenizer_path = os.path.join(search_sub_dir_in_possible_folders(possible_folders, sub_dir_name="FLUX.2-dev"), "tokenizer")
-            except:
+            except Exception:
                 tokenizer_path = search_sub_dir_in_possible_folders(possible_folders, sub_dir_name="Mistral-Nemo-Instruct-2407")
 
         tokenizer = PixtralProcessor.from_pretrained(tokenizer_path)

--- a/comfyui/qwenimage/nodes.py
+++ b/comfyui/qwenimage/nodes.py
@@ -476,10 +476,10 @@ class LoadQwenImageTextEncoderModel:
             [os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "models/Diffusion_Transformer")] # Possible folder names to check
         try:
             tokenizer_path = search_sub_dir_in_possible_folders(possible_folders, sub_dir_name="qwen2_tokenizer")
-        except:
+        except Exception:
             try:
                 tokenizer_path = os.path.join(search_sub_dir_in_possible_folders(possible_folders, sub_dir_name="Qwen-Image"), "tokenizer")
-            except:
+            except Exception:
                 tokenizer_path = search_sub_dir_in_possible_folders(possible_folders, sub_dir_name="Qwen2.5-VL-7B-Instruct")
 
         tokenizer = Qwen2Tokenizer.from_pretrained(tokenizer_path)
@@ -504,10 +504,10 @@ class LoadQwenImageProcessor:
             [os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "models/Diffusion_Transformer")] # Possible folder names to check
         try:
             processor_path = search_sub_dir_in_possible_folders(possible_folders, sub_dir_name="qwen2_processor")
-        except:
+        except Exception:
             try:
                 processor_path = os.path.join(search_sub_dir_in_possible_folders(possible_folders, sub_dir_name="Qwen-Image-Edit"), "processor")
-            except:
+            except Exception:
                 processor_path = search_sub_dir_in_possible_folders(possible_folders, sub_dir_name="Qwen2.5-VL-7B-Instruct")
 
         # Get processor

--- a/comfyui/z_image/nodes.py
+++ b/comfyui/z_image/nodes.py
@@ -435,10 +435,10 @@ class LoadZImageTextEncoderModel:
             [os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), "models/Diffusion_Transformer")] # Possible folder names to check
         try:
             tokenizer_path = search_sub_dir_in_possible_folders(possible_folders, sub_dir_name="qwen3_tokenizer")
-        except:
+        except Exception:
             try:
                 tokenizer_path = os.path.join(search_sub_dir_in_possible_folders(possible_folders, sub_dir_name="Z-Image-Turbo"), "tokenizer")
-            except:
+            except Exception:
                 tokenizer_path = search_sub_dir_in_possible_folders(possible_folders, sub_dir_name="Qwen3-4B")
 
         tokenizer = AutoTokenizer.from_pretrained(tokenizer_path)

--- a/scripts/cogvideox_fun/train.py
+++ b/scripts/cogvideox_fun/train.py
@@ -1001,7 +1001,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/cogvideox_fun/train_control.py
+++ b/scripts/cogvideox_fun/train_control.py
@@ -961,7 +961,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/cogvideox_fun/train_lora.py
+++ b/scripts/cogvideox_fun/train_lora.py
@@ -1008,7 +1008,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/cogvideox_fun/train_reward_lora.py
+++ b/scripts/cogvideox_fun/train_reward_lora.py
@@ -969,7 +969,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/fantasytalking/train.py
+++ b/scripts/fantasytalking/train.py
@@ -1013,7 +1013,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/flux/train.py
+++ b/scripts/flux/train.py
@@ -1023,7 +1023,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/flux/train_lora.py
+++ b/scripts/flux/train_lora.py
@@ -1021,7 +1021,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/flux2/train.py
+++ b/scripts/flux2/train.py
@@ -1115,7 +1115,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/flux2/train_lora.py
+++ b/scripts/flux2/train_lora.py
@@ -1082,7 +1082,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/flux2_fun/train_control.py
+++ b/scripts/flux2_fun/train_control.py
@@ -1137,7 +1137,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/flux2_fun/train_control_distill.py
+++ b/scripts/flux2_fun/train_control_distill.py
@@ -1127,7 +1127,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/hunyuanvideo/train.py
+++ b/scripts/hunyuanvideo/train.py
@@ -1136,7 +1136,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/hunyuanvideo/train_lora.py
+++ b/scripts/hunyuanvideo/train_lora.py
@@ -1137,7 +1137,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/longcatvideo/train.py
+++ b/scripts/longcatvideo/train.py
@@ -1017,7 +1017,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/longcatvideo/train_avatar.py
+++ b/scripts/longcatvideo/train_avatar.py
@@ -1057,7 +1057,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/longcatvideo/train_avatar_lora.py
+++ b/scripts/longcatvideo/train_avatar_lora.py
@@ -1044,7 +1044,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/longcatvideo/train_lora.py
+++ b/scripts/longcatvideo/train_lora.py
@@ -1000,7 +1000,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/qwenimage/train.py
+++ b/scripts/qwenimage/train.py
@@ -924,7 +924,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/qwenimage/train_edit.py
+++ b/scripts/qwenimage/train_edit.py
@@ -960,7 +960,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/qwenimage/train_edit_lora.py
+++ b/scripts/qwenimage/train_edit_lora.py
@@ -962,7 +962,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/qwenimage/train_lora.py
+++ b/scripts/qwenimage/train_lora.py
@@ -918,7 +918,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/qwenimage_fun/train_control.py
+++ b/scripts/qwenimage_fun/train_control.py
@@ -954,7 +954,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/qwenimage_instantx/train_control.py
+++ b/scripts/qwenimage_instantx/train_control.py
@@ -947,7 +947,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/turbodiffusion/train_distill.py
+++ b/scripts/turbodiffusion/train_distill.py
@@ -1071,7 +1071,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/wan2.1/train.py
+++ b/scripts/wan2.1/train.py
@@ -1079,7 +1079,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/wan2.1/train_distill.py
+++ b/scripts/wan2.1/train_distill.py
@@ -1070,7 +1070,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/wan2.1/train_distill_lora.py
+++ b/scripts/wan2.1/train_distill_lora.py
@@ -1130,7 +1130,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/wan2.1/train_lora.py
+++ b/scripts/wan2.1/train_lora.py
@@ -1068,7 +1068,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/wan2.1/train_reward_lora.py
+++ b/scripts/wan2.1/train_reward_lora.py
@@ -978,7 +978,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/wan2.1_fun/train.py
+++ b/scripts/wan2.1_fun/train.py
@@ -1037,7 +1037,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/wan2.1_fun/train_control.py
+++ b/scripts/wan2.1_fun/train_control.py
@@ -983,7 +983,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/wan2.1_fun/train_control_lora.py
+++ b/scripts/wan2.1_fun/train_control_lora.py
@@ -981,7 +981,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/wan2.1_fun/train_lora.py
+++ b/scripts/wan2.1_fun/train_lora.py
@@ -1030,7 +1030,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/wan2.1_fun/train_reward_lora.py
+++ b/scripts/wan2.1_fun/train_reward_lora.py
@@ -990,7 +990,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/wan2.1_vace/train.py
+++ b/scripts/wan2.1_vace/train.py
@@ -968,7 +968,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/wan2.2/train.py
+++ b/scripts/wan2.2/train.py
@@ -1097,7 +1097,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/wan2.2/train_animate.py
+++ b/scripts/wan2.2/train_animate.py
@@ -1061,7 +1061,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/wan2.2/train_animate_lora.py
+++ b/scripts/wan2.2/train_animate_lora.py
@@ -1066,7 +1066,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/wan2.2/train_distill.py
+++ b/scripts/wan2.2/train_distill.py
@@ -1101,7 +1101,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/wan2.2/train_distill_lora.py
+++ b/scripts/wan2.2/train_distill_lora.py
@@ -1157,7 +1157,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/wan2.2/train_lora.py
+++ b/scripts/wan2.2/train_lora.py
@@ -1097,7 +1097,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/wan2.2/train_s2v.py
+++ b/scripts/wan2.2/train_s2v.py
@@ -1057,7 +1057,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/wan2.2/train_s2v_lora.py
+++ b/scripts/wan2.2/train_s2v_lora.py
@@ -1072,7 +1072,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/wan2.2_fun/train.py
+++ b/scripts/wan2.2_fun/train.py
@@ -1066,7 +1066,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/wan2.2_fun/train_control.py
+++ b/scripts/wan2.2_fun/train_control.py
@@ -1064,7 +1064,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/wan2.2_fun/train_control_lora.py
+++ b/scripts/wan2.2_fun/train_control_lora.py
@@ -1062,7 +1062,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/wan2.2_fun/train_lora.py
+++ b/scripts/wan2.2_fun/train_lora.py
@@ -1059,7 +1059,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/wan2.2_fun/train_reward_lora.py
+++ b/scripts/wan2.2_fun/train_reward_lora.py
@@ -1134,7 +1134,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/wan2.2_vace_fun/train.py
+++ b/scripts/wan2.2_vace_fun/train.py
@@ -1007,7 +1007,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/z_image/train.py
+++ b/scripts/z_image/train.py
@@ -966,7 +966,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/z_image/train_distill.py
+++ b/scripts/z_image/train_distill.py
@@ -1003,7 +1003,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/z_image/train_distill_lora.py
+++ b/scripts/z_image/train_distill_lora.py
@@ -1027,7 +1027,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/z_image/train_lora.py
+++ b/scripts/z_image/train_lora.py
@@ -942,7 +942,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/z_image_fun/train_control.py
+++ b/scripts/z_image_fun/train_control.py
@@ -1025,7 +1025,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/scripts/z_image_fun/train_control_distill.py
+++ b/scripts/z_image_fun/train_control_distill.py
@@ -1071,7 +1071,7 @@ def main():
     elif args.use_came:
         try:
             from came_pytorch import CAME
-        except:
+        except Exception:
             raise ImportError(
                 "Please install came_pytorch to use CAME. You can do so by running `pip install came_pytorch`"
             )

--- a/videox_fun/api/api_multi_nodes.py
+++ b/videox_fun/api/api_multi_nodes.py
@@ -18,7 +18,7 @@ from .api import download_from_url, encode_file_to_base64
 
 try:
     import ray
-except:
+except Exception:
     print("Ray is not installed. If you want to use multi gpus api. Please install it by running 'pip install ray'.")
     ray =  None
 

--- a/videox_fun/models/__init__.py
+++ b/videox_fun/models/__init__.py
@@ -14,7 +14,7 @@ try:
     from transformers import (Qwen2_5_VLConfig,
                               Qwen2_5_VLForConditionalGeneration,
                               Qwen2Tokenizer, Qwen2VLProcessor)
-except:
+except Exception:
     Qwen2_5_VLForConditionalGeneration, Qwen2Tokenizer = None, None
     Qwen2VLProcessor, Qwen2_5_VLConfig = None, None
     print("Your transformers version is too old to load Qwen2_5_VLForConditionalGeneration and Qwen2Tokenizer. If you wish to use QwenImage, please upgrade your transformers package to the latest version.")

--- a/videox_fun/models/attention_utils.py
+++ b/videox_fun/models/attention_utils.py
@@ -33,11 +33,11 @@ try:
     elif major>9:
         from sageattention_sm120 import sageattn
         SAGE_ATTENTION_AVAILABLE = True
-except:
+except Exception:
     try:
         from sageattention import sageattn
         SAGE_ATTENTION_AVAILABLE = True
-    except:
+    except Exception:
         sageattn = None
         SAGE_ATTENTION_AVAILABLE = False
 
@@ -61,7 +61,7 @@ def convert_qkv_dtype(q, k, v):
             return q, k, v  # No conversion for other cases
         
         return q.to(target_dtype), k.to(target_dtype), v.to(target_dtype)
-    except:
+    except Exception:
         return q, k, v
 
 

--- a/videox_fun/models/fantasytalking_audio_encoder.py
+++ b/videox_fun/models/fantasytalking_audio_encoder.py
@@ -31,7 +31,7 @@ class FantasyTalkingAudioEncoder(ModelMixin, ConfigMixin, FromOriginalModelMixin
 
         try:
             audio_segment = audio_input[start_sample:end_sample]
-        except:
+        except Exception:
             audio_segment = audio_input
 
         input_values = self.processor(

--- a/videox_fun/ui/controller.py
+++ b/videox_fun/ui/controller.py
@@ -482,7 +482,7 @@ class Fun_Controller_Client:
 
         try:
             base64_encoding = outputs["base64_encoding"]
-        except:
+        except Exception:
             return gr.Image(visible=False, value=None), gr.Video(None, visible=True), outputs["message"]
             
         decoded_data = base64.b64decode(base64_encoding)

--- a/videox_fun/video_caption/compute_text_score.py
+++ b/videox_fun/video_caption/compute_text_score.py
@@ -71,7 +71,7 @@ def compute_text_score(video_path, ocr_reader, sample_method="mid", num_sampled_
                 quad_area += triangle_area(*triangle1)
                 triangle2 = points[3:] + [points[0]]
                 quad_area += triangle_area(*triangle2)
-        except:
+        except Exception:
             quad_area = 0
         text_area = rect_area + quad_area
 

--- a/videox_fun/video_caption/package_patches/easyocr_detection_patched.py
+++ b/videox_fun/video_caption/package_patches/easyocr_detection_patched.py
@@ -84,7 +84,7 @@ def get_detector(trained_model, device='cpu', quantize=True, cudnn_benchmark=Fal
         if quantize:
             try:
                 torch.quantization.quantize_dynamic(net, dtype=torch.qint8, inplace=True)
-            except:
+            except Exception:
                 pass
     else:
         net.load_state_dict(copyStateDict(torch.load(trained_model, map_location=device)))

--- a/videox_fun/video_caption/utils/longclip/simple_tokenizer.py
+++ b/videox_fun/video_caption/utils/longclip/simple_tokenizer.py
@@ -98,7 +98,7 @@ class SimpleTokenizer(object):
                     j = word.index(first, i)
                     new_word.extend(word[i:j])
                     i = j
-                except:
+                except Exception:
                     new_word.extend(word[i:])
                     break
 

--- a/videox_fun/video_caption/utils/viclip/simple_tokenizer.py
+++ b/videox_fun/video_caption/utils/viclip/simple_tokenizer.py
@@ -101,7 +101,7 @@ class SimpleTokenizer(object):
                     j = word.index(first, i)
                     new_word.extend(word[i:j])
                     i = j
-                except:
+                except Exception:
                     new_word.extend(word[i:])
                     break
 


### PR DESCRIPTION
Replace 74 bare `except:` with `except Exception:` across 67 files. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, masking real errors.