### PR TITLE
feat: expose package version in top-level API

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,10 @@
 from .comfyui.comfyui_nodes import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
 
-__all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS"]
+__version__ = "1.0.1"
+
+__all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS", "__version__", "get_version"]
+
+
+def get_version() -> str:
+    """Return the VideoX-Fun version."""
+    return __version__


### PR DESCRIPTION
## Summary
- add `__version__` constant to top-level package module
- add typed `get_version() -> str` helper for programmatic version reads
- export `__version__` and `get_version` via `__all__`

## Why
Downstream integrations often need an explicit version entrypoint from the root package. This keeps version access consistent with other Python tooling patterns.

## Testing
- [x] import path remains unchanged
- [x] change is additive and backward-compatible
