### PR TITLE
feat: expose package version for runtime checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ English | [简体中文](./README_zh-CN.md) | [日本語](./README_ja-JP.md)
 - [Table of Contents](#table-of-contents)
 - [Introduction](#introduction)
 - [Quick Start](#quick-start)
+- [Version Check](#version-check)
 - [Video Result](#video-result)
 - [How to use](#how-to-use)
 - [Model zoo](#model-zoo)
@@ -89,6 +90,16 @@ mkdir models/Personalized_Model
 ```
 
 ### 2. Local install: Environment Check/Downloading/Installation
+
+## Version Check
+
+After installation, you can verify the installed package version from Python:
+
+```python
+import videox_fun
+
+print(videox_fun.__version__)
+```
 #### a. Environment Check
 We have verified this repo execution on the following environment:
 

--- a/videox_fun/__init__.py
+++ b/videox_fun/__init__.py
@@ -1,0 +1,8 @@
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("videox-fun")
+except PackageNotFoundError:
+    __version__ = "0.0.0"
+
+__all__ = ["__version__"]


### PR DESCRIPTION
## Summary
- add `videox_fun.__version__` resolved from installed package metadata
- add a safe fallback version (`0.0.0`) when package metadata is unavailable
- document a short "Version Check" snippet in README

## Why
This gives users a stable runtime way to confirm installed package version and aligns docs with package API.

## Testing
- [x] additive and backward-compatible
- [x] docs snippet matches exported package symbol
