### PR TITLE
docs: fix Aliyun quick start grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Our UI interface is as follows:
 #### a. From AliyunDSW
 DSW has free GPU time, which can be applied once by a user and is valid for 3 months after applying.
 
-Aliyun provide free GPU time in [Freetier](https://free.aliyun.com/?product=9602825&crowd=enterprise&spm=5176.28055625.J_5831864660.1.e939154aRgha4e&scm=20140722.M_9974135.P_110.MO_1806-ID_9974135-MID_9974135-CID_30683-ST_8512-V_1), get it and use in Aliyun PAI-DSW to start CogVideoX-Fun within 5min!
+Aliyun provides free GPU time in [Freetier](https://free.aliyun.com/?product=9602825&crowd=enterprise&spm=5176.28055625.J_5831864660.1.e939154aRgha4e&scm=20140722.M_9974135.P_110.MO_1806-ID_9974135-MID_9974135-CID_30683-ST_8512-V_1). You can use it in Aliyun PAI-DSW to start CogVideoX-Fun within 5 minutes.
 
 [![DSW Notebook](https://pai-aigc-photog.oss-cn-hangzhou.aliyuncs.com/easyanimate/asset/dsw.png)](https://gallery.pai-ml.com/#/preview/deepLearning/cv/cogvideox_fun)
 


### PR DESCRIPTION
## Summary
- fix grammar in the Aliyun DSW quick-start sentence
- improve readability by splitting one long sentence into two

## Why
Makes setup instructions clearer for English readers in a key onboarding section.

## Testing
- [x] docs-only change
