### PR TITLE
docs: fix model download link wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ cd VideoX-Fun
 mkdir models/Diffusion_Transformer
 mkdir models/Personalized_Model
 
-# Please use the hugginface link or modelscope link to download the model.
+# Please use the Hugging Face link or ModelScope link to download the model.
 # CogVideoX-Fun
 # https://huggingface.co/alibaba-pai/CogVideoX-Fun-V1.1-5b-InP
 # https://modelscope.cn/models/PAI/CogVideoX-Fun-V1.1-5b-InP


### PR DESCRIPTION
## Summary
- fix README wording in model download instruction
- update `hugginface` -> `Hugging Face`
- update `modelscope` -> `ModelScope`

## Why
Uses official product names and improves readability in setup instructions.

## Testing
- [x] docs-only change
