### PR TITLE
docs: fix environment heading grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ mkdir models/Personalized_Model
 #### a. Environment Check
 We have verified this repo execution on the following environment:
 
-The detailed of Windows:
+Windows environment details:
 - OS: Windows 10
 - python: python3.10 & python3.11
 - pytorch: torch2.2.0
@@ -100,7 +100,7 @@ The detailed of Windows:
 - CUDNN: 8+
 - GPU： Nvidia-3060 12G & Nvidia-3090 24G
 
-The detailed of Linux:
+Linux environment details:
 - OS: Ubuntu 20.04, CentOS
 - python: python3.10 & python3.11
 - pytorch: torch2.2.0


### PR DESCRIPTION
## Summary
- fix README environment subsection headings
- update `The detailed of Windows` -> `Windows environment details`
- update `The detailed of Linux` -> `Linux environment details`

## Why
Improves grammar and readability in installation prerequisites.

## Testing
- [x] docs-only change
