### PR TITLE
docs: improve weights placement wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The detailed of Linux:
 We need about 60GB available on disk (for saving weights), please check!
 
 #### b. Weights
-We'd better place the [weights](#model-zoo) along the specified path:
+We recommend placing the [weights](#model-zoo) along the specified path:
 
 **Via ComfyUI**:
 Put the models into the ComfyUI weights folder `ComfyUI/models/Fun_Models/`:


### PR DESCRIPTION
## Summary
- improve wording in weights placement instruction
- change We'd better -> We recommend placing

## Why
More professional tone in setup instructions.

## Testing
- [x] docs-only change