### PR TITLE
fix: use dtype instead of deprecated torch_dtype

### DIFF
--- a/examples/z_image_fun/predict_t2i_control_2.1_lite.py
+++ b/examples/z_image_fun/predict_t2i_control_2.1_lite.py
@@ -28,6 +28,15 @@ from videox_fun.utils.utils import (filter_kwargs, get_image, get_image_latent,
                                     get_image_to_video_latent,
                                     get_video_to_video_latent,
                                     save_videos_grid)
+import transformers
+from packaging.version import Version
+
+def _dtype_kwargs(dtype):
+    """`dtype` keyword of `from_pretrained` exists since transformers 4.56 (PR #39782);
+    older versions use `torch_dtype`."""
+    if Version(transformers.__version__) >= Version("4.56"):
+        return {"dtype": dtype}
+    return {"torch_dtype": dtype}
 
 # GPU memory mode, which can be chosen in [model_full_load, model_full_load_and_qfloat8, model_cpu_offload, model_cpu_offload_and_qfloat8, sequential_cpu_offload].
 # model_full_load means that the entire model will be moved to the GPU.
@@ -138,7 +147,7 @@ tokenizer = AutoTokenizer.from_pretrained(
     model_name, subfolder="tokenizer"
 )
 text_encoder = Qwen3ForCausalLM.from_pretrained(
-    model_name, subfolder="text_encoder", torch_dtype=weight_dtype,
+    model_name, subfolder="text_encoder", **_dtype_kwargs(weight_dtype),
     low_cpu_mem_usage=True,
 )
 

--- a/examples/z_image_fun/predict_turbo_t2i_control_2.1.py
+++ b/examples/z_image_fun/predict_turbo_t2i_control_2.1.py
@@ -28,6 +28,15 @@ from videox_fun.utils.utils import (filter_kwargs, get_image, get_image_latent,
                                     get_image_to_video_latent,
                                     get_video_to_video_latent,
                                     save_videos_grid)
+import transformers
+from packaging.version import Version
+
+def _dtype_kwargs(dtype):
+    """`dtype` keyword of `from_pretrained` exists since transformers 4.56 (PR #39782);
+    older versions use `torch_dtype`."""
+    if Version(transformers.__version__) >= Version("4.56"):
+        return {"dtype": dtype}
+    return {"torch_dtype": dtype}
 
 # GPU memory mode, which can be chosen in [model_full_load, model_full_load_and_qfloat8, model_cpu_offload, model_cpu_offload_and_qfloat8, sequential_cpu_offload].
 # model_full_load means that the entire model will be moved to the GPU.
@@ -137,17 +146,10 @@ if vae_path is not None:
 tokenizer = AutoTokenizer.from_pretrained(
     model_name, subfolder="tokenizer"
 )
-try:
-    text_encoder = Qwen3ForCausalLM.from_pretrained(
-        model_name, subfolder="text_encoder", dtype=weight_dtype,
-        low_cpu_mem_usage=True,
-    )
-except TypeError:
-    # transformers < 4.56: `dtype` is not accepted yet
-    text_encoder = Qwen3ForCausalLM.from_pretrained(
-        model_name, subfolder="text_encoder", torch_dtype=weight_dtype,
-        low_cpu_mem_usage=True,
-    )
+text_encoder = Qwen3ForCausalLM.from_pretrained(
+    model_name, subfolder="text_encoder", **_dtype_kwargs(weight_dtype),
+    low_cpu_mem_usage=True,
+)
 
 # Get Scheduler
 Chosen_Scheduler = scheduler_dict = {

--- a/examples/z_image_fun/predict_turbo_t2i_control_2.1.py
+++ b/examples/z_image_fun/predict_turbo_t2i_control_2.1.py
@@ -137,10 +137,17 @@ if vae_path is not None:
 tokenizer = AutoTokenizer.from_pretrained(
     model_name, subfolder="tokenizer"
 )
-text_encoder = Qwen3ForCausalLM.from_pretrained(
-    model_name, subfolder="text_encoder", torch_dtype=weight_dtype,
-    low_cpu_mem_usage=True,
-)
+try:
+    text_encoder = Qwen3ForCausalLM.from_pretrained(
+        model_name, subfolder="text_encoder", dtype=weight_dtype,
+        low_cpu_mem_usage=True,
+    )
+except TypeError:
+    # transformers < 4.56: `dtype` is not accepted yet
+    text_encoder = Qwen3ForCausalLM.from_pretrained(
+        model_name, subfolder="text_encoder", torch_dtype=weight_dtype,
+        low_cpu_mem_usage=True,
+    )
 
 # Get Scheduler
 Chosen_Scheduler = scheduler_dict = {


### PR DESCRIPTION
## Summary

`config.torch_dtype` and the `torch_dtype` keyword argument were deprecated in transformers 4.56 (PR #39782) and replaced by `dtype`. This PR updates the `Qwen3ForCausalLM.from_pretrained` text-encoder calls in `examples/z_image_fun/predict_turbo_t2i_control_2.1.py` and `examples/z_image_fun/predict_t2i_control_2.1_lite.py` (line 140 in both) to select the keyword from the installed transformers version using `packaging.version`, so transformers < 4.56 keeps working. (The diffusers-based `ZImageControlTransformer2DModel` call is untouched.)

## Changes

- Both `examples/z_image_fun/predict_*_control_2.1*.py`: add a `_dtype_kwargs` helper that returns `{"dtype": ...}` on transformers >= 4.56 and `{"torch_dtype": ...}` otherwise; the `Qwen3ForCausalLM.from_pretrained` call passes it as `**_dtype_kwargs(weight_dtype)`.

## Test

- Both modified files compile (`python -m py_compile`).
- On transformers >= 4.56 the call uses `dtype` and emits no deprecation warning; on older versions it passes `torch_dtype` unchanged.

Fixes #513